### PR TITLE
[AIOFile.write] Handle partial writes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
     extras_require={
         "develop": [
             "aiomisc",
+            "asynctest",
             "pytest",
             "pytest-cov",
         ],


### PR DESCRIPTION
Data can be written by the system only partially. See, for example, [write(2)](https://www.man7.org/linux/man-pages/man2/write.2.html).
It can happen, e.g. when a disk quota or a resource limit is exceeded (in that case subsequent call will return a corresponding error) or write has been interrupted by an incoming signal.

Old implementation was to basically ignore such thing. It may lead to file being corrupted if disk space is nearly zero and if the user code does not handle or does not handle properly the return code of the `.write(...)` call.

Since aiofile is a high-level library, I propose to handle partial writes here: try to write the remaining part again, and do not defer it to user.