### PR TITLE
Fix for TextFileWrapper file offset calculation

### DIFF
--- a/aiofile/utils.py
+++ b/aiofile/utils.py
@@ -305,7 +305,8 @@ class TextFileWrapper(FileIOWrapperBase):
 
                     fp.seek(0)
                     line = fp.readline()
-                    self._offset = offset + fp.tell()
+                    self._offset = offset + len(
+                        line.encode(encoding=self.encoding))
                     return line
 
 


### PR DESCRIPTION
When you try to calculate the offset of the next position to start reading from you mix pure bytes and some other string with other encoding (from IOString buffer) and it works fine until all symbols in IOString buffer are Ascii symbols, but once you hit some other symbols like Cyrillic ones you will get a smaller length of the string (as len() would return a number of symbols and not bytes) and as a result the offset would be smaller as well. That would lead to the repeated reading of the part of the previous line.
Tried myself while parsing database logs.