### PR TITLE
Include py.typed file in the package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,4 @@ recursive-exclude systemd *.pyc
 recursive-exclude __pycache__ *
 recursive-include aiofile *.pyx *.pxd *.pyi
 exclude .*
-include README.md
+include README.md aiofile/py.typed


### PR DESCRIPTION
Currently py.typed file is not included in the output package so mypy doesn't recognize that this library is typed.

Missing file:
![image](https://user-images.githubusercontent.com/19969687/146461994-377d1183-3981-4fa4-ba13-f2c29665caa1.png)
