### PR TITLE
Include py.typed file in the output package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     name="aiofile",
     version=module.__version__,
     packages=["aiofile"],
+    include_package_data=True,
     license=module.package_license,
     description=module.package_info,
     long_description=open("README.rst").read(),


### PR DESCRIPTION
Include py.typed file in the output package.

https://setuptools.pypa.io/en/latest/userguide/datafiles.html