### PR TITLE
fix: make python version conform to pep440

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         "Topic :: System",
         "Topic :: System :: Operating System",
     ],
-    python_requires=">3.4.*, <4",
+    python_requires=">3.4, <4",
     extras_require={
         "develop": [
             "aiomisc",


### PR DESCRIPTION
Poetry throws an error when reading `3.4.*` and removing "*" means the same thing, I think.

```
InvalidVersion

  Invalid PEP 440 version: '3.4.'

  at /usr/local/share/anaconda3/envs/py39/lib/python3.9/site-packages/poetry/core/version/pep440/parser.py:67 in parse
       63│     @classmethod
       64│     def parse(cls, value: str, version_class: Optional[Type["PEP440Version"]] = None):
       65│         match = cls._regex.search(value) if value else None
       66│         if not match:
    →  67│             raise InvalidVersion(f"Invalid PEP 440 version: '{value}'")
       68│ 
       69│         if version_class is None:
       70│             from poetry.core.version.pep440.version import PEP440Version
       71│ 

The following error occurred when trying to handle this error:


  ValueError

  Could not parse version constraint: >3.4.*

  at /usr/local/share/anaconda3/envs/py39/lib/python3.9/site-packages/poetry/core/semver/helpers.py:139 in parse_single_constraint
      135│ 
      136│         try:
      137│             version = Version.parse(version)
      138│         except ValueError:
    → 139│             raise ValueError(
      140│                 "Could not parse version constraint: {}".format(constraint)
      141│             )
      142│ 
      143│         if op == "<":
```