### PR TITLE
Prevent concurrent AIOFile.open() calls re-opening the file

### DIFF
--- a/aiofile/aio.py
+++ b/aiofile/aio.py
@@ -165,10 +165,9 @@ class AIOFile:
 
     async def open(self) -> Optional[int]:
         if self._file_obj is not None:
+            if self._file_obj.closed:
+                raise asyncio.InvalidStateError("AIOFile closed")
             return None
-
-        if self._file_obj and self._file_obj.closed:
-            raise asyncio.InvalidStateError("AIOFile closed")
 
         self._file_obj = await self._run_in_thread(
             open, self._fname, self._open_mode,

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -211,6 +211,17 @@ async def test_sequential_open(aio_file_maker, temp_file):
         await file.open()
 
 
+async def test_parallel_open(aio_file_maker, temp_file):
+    file = aio_file_maker(temp_file, "r")
+    try:
+        # open() returns a file descriptor if it has opened a file, otherwise
+        # None. Only one of multiple parallel calls should actually open a file.
+        opens = await asyncio.gather(*(file.open() for _ in range(3)))
+        assert len([fd for fd in opens if fd is not None]) == 1
+    finally:
+        await file.close()
+
+
 async def test_line_reader(aio_file_maker, temp_file, uuid):
     afp = await aio_file_maker(temp_file, "w+")
 

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -199,6 +199,18 @@ async def test_non_existent_file_ctx(aio_file_maker):
             pass
 
 
+async def test_sequential_open(aio_file_maker, temp_file):
+    file = aio_file_maker(temp_file, "r")
+    try:
+        assert isinstance(await file.open(), int)
+        assert await file.open() is None
+    finally:
+        await file.close()
+
+    with pytest.raises(asyncio.InvalidStateError):
+        await file.open()
+
+
 async def test_line_reader(aio_file_maker, temp_file, uuid):
     afp = await aio_file_maker(temp_file, "w+")
 


### PR DESCRIPTION
I implemented this with an `asyncio.Lock` as you suggested ( f6b5b468041c005aa879c54764aeb77474551728 ), but then I noticed that `_run_in_thread(open, ...)` that provides the file obj returns an `asyncio.Future`, so we can use that to synchronise callers without needing an explicit lock. Either seems fine to me.

Also, I noticed a related minor bug while doing this. It seems the intention of the code was that calling `open()` after a previous `close()` would raise an `InvalidStateError`, but in fact this could never happen, as `open()` would always return from the first if statement before check to raise the error would happen.

This fixes https://github.com/mosquito/aiofile/issues/68.