### PR TITLE
Feature/clone function

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,54 @@ async def main():
 asyncio.run(main())
 ```
 
+### `clone` helper
+
+Asynchronous context at a low level supports a limited number of concurrency
+operations, no matter how many file descriptors are open. This means that you
+can make a second file-like object with its own offset for one descriptor
+without opening the file several times.
+
+```python
+"""
+This example counts multiple hash functions from the file passed as the first
+argument. The hash functions are counted competitively, and the results are
+printed in the order of hashing completion.
+"""
+import asyncio
+import hashlib
+import sys
+
+import aiofile
+
+
+async def hasher(name, hash_func, afp):
+    loop = asyncio.get_running_loop()
+    async for chunk in afp.iter_chunked(2 ** 20):
+        await loop.run_in_executor(None, hash_func.update, chunk)
+    print(name, hash_func.hexdigest())
+
+
+async def main():
+    async with aiofile.async_open(sys.argv[1], "rb") as source:
+        hashers = [
+            ("MD5", hashlib.md5()),
+            ("SHA1", hashlib.sha1()),
+            ("SHA256", hashlib.sha256()),
+            ("SHA512", hashlib.sha512()),
+        ]
+
+        await asyncio.gather(*[
+            hasher(name, hash_func, await aiofile.clone(source))
+            for name, hash_func in hashers
+        ])
+
+
+asyncio.run(main())
+```
+
+> **Note:** This will most likely perform poorly on Windows, so if that's
+> your target platform this optimization may not be worth it.
+
 ### Low-level API
 
 The `AIOFile` class is a low-level interface for asynchronous file operations, and the read and write methods accept

--- a/aiofile/__init__.py
+++ b/aiofile/__init__.py
@@ -1,7 +1,7 @@
 from .aio import AIOFile
 from .utils import (
-    BinaryFileWrapper, FileIOWrapperBase, LineReader, Reader, TextFileWrapper,
-    Writer, async_open,
+    BinaryFileWrapper, FileIOCloner, FileIOWrapperBase, LineReader, Reader,
+    TextFileWrapper, Writer, async_open, clone,
 )
 from .version import (
     __author__, __version__, author_info, package_info, package_license,
@@ -12,6 +12,7 @@ from .version import (
 __all__ = (
     "AIOFile",
     "BinaryFileWrapper",
+    "FileIOCloner",
     "FileIOWrapperBase",
     "LineReader",
     "Reader",
@@ -21,6 +22,7 @@ __all__ = (
     "__version__",
     "async_open",
     "author_info",
+    "clone",
     "package_info",
     "package_license",
     "project_home",

--- a/aiofile/aio.py
+++ b/aiofile/aio.py
@@ -139,6 +139,8 @@ class AIOFile:
         self._file_obj_owner = True
         self._encoding = encoding
         self._executor = executor
+        self._clone_lock = asyncio.Lock()
+        self._clones = 0
 
     @classmethod
     def from_fp(cls, fp: FileIOType, **kwargs: Any) -> "AIOFile":
@@ -188,9 +190,21 @@ class AIOFile:
     def __repr__(self) -> str:
         return "<AIOFile: %r>" % self._fname
 
+    async def clone(self) -> "AIOFile":
+        """Returns self with a ref-count bump; close() is deferred until all
+        clones are released."""
+        async with self._clone_lock:
+            self._clones += 1
+            return self
+
     async def close(self) -> None:
         if self._file_obj is None or not self._file_obj_owner:
             return
+
+        async with self._clone_lock:
+            if self._clones > 0:
+                self._clones -= 1
+                return
 
         if self.mode.writable:
             await self.fdsync()

--- a/aiofile/utils.py
+++ b/aiofile/utils.py
@@ -5,7 +5,7 @@ import os
 from abc import ABC, abstractmethod
 from pathlib import Path
 from types import MappingProxyType
-from typing import Any, Generator, Tuple, Union
+from typing import Any, Generator, Generic, Optional, Tuple, TypeVar, Union
 
 from .aio import AIOFile, FileIOType
 
@@ -350,13 +350,48 @@ def async_open(
     return BinaryFileWrapper(afp)
 
 
+T = TypeVar("T", bound=FileIOWrapperBase)
+
+
+class FileIOCloner(Generic[T]):
+    def __init__(self, file: T):
+        self.source_afp = file
+        self.cloned_afp: Optional[T] = None
+        self._lock = asyncio.Lock()
+
+    async def __clone(self) -> T:
+        async with self._lock:
+            if self.cloned_afp is not None:
+                return self.cloned_afp
+            self.cloned_afp = self.source_afp.__class__(
+                await self.source_afp.file.clone(),
+            )
+        return self.cloned_afp
+
+    def __await__(self) -> Generator[Any, None, T]:
+        return self.__clone().__await__()
+
+    async def __aenter__(self) -> T:
+        return await self.__clone()
+
+    async def __aexit__(self, *_: Any) -> None:
+        if self.cloned_afp is not None:
+            await self.cloned_afp.close()
+
+
+def clone(afp: FileIOWrapperBase) -> "FileIOCloner[FileIOWrapperBase]":
+    return FileIOCloner(afp)
+
+
 __all__ = (
     "BinaryFileWrapper",
+    "FileIOCloner",
     "FileIOWrapperBase",
     "LineReader",
     "Reader",
     "TextFileWrapper",
     "Writer",
     "async_open",
+    "clone",
     "unicode_reader",
 )

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -13,7 +13,7 @@ from uuid import uuid4
 import caio
 import pytest
 
-from aiofile import AIOFile
+from aiofile import AIOFile, clone
 from aiofile.utils import (
     BinaryFileWrapper, LineReader, Reader, TextFileWrapper, Writer,
 )
@@ -629,3 +629,50 @@ async def test_open_non_existent_file_with_append(
             numbers.append(int(line.strip()))
 
     assert numbers == list(range(20))
+
+
+async def test_clone(
+    async_open, tmp_path: Path,
+):
+    tmp_fpath = tmp_path / "test.txt"
+
+    async with async_open(tmp_fpath, "w") as afp:
+        for i in range(1000, 1003):
+            await afp.write(str(i))
+            await afp.write("\n")
+
+    async with async_open(tmp_fpath, "r") as afp:
+        assert await afp.read(5) == "1000\n"
+
+        async with clone(afp) as cloned:
+            assert await cloned.read(5) == "1000\n"
+
+            async with clone(afp) as cloned2:
+                assert await cloned2.read(5) == "1000\n"
+
+                assert await cloned.read(5) == await afp.read(5) == "1001\n"
+
+
+async def test_clone_close(
+    async_open, tmp_path: Path,
+):
+    tmp_fpath = tmp_path / "test.txt"
+
+    async with async_open(tmp_fpath, "w") as afp:
+        for i in range(10):
+            await afp.write(str(i))
+            await afp.write("\n")
+
+    async with async_open(tmp_fpath, "r") as afp:
+        await afp.read(10)
+
+        afp_clone = await clone(afp)
+        await afp_clone.close()
+
+        assert await afp.read()
+
+    async with async_open(tmp_fpath, "r") as afp:
+        await afp.read(10)
+
+        async with clone(afp):
+            assert await afp.read()


### PR DESCRIPTION
This pull request introduces a new asynchronous file cloning feature to the `aiofile` library, allowing multiple independent file-like objects to share a single file descriptor with separate offsets. This enables concurrent reading (and potentially writing) from the same file without reopening it, which can improve performance in certain scenarios. The change includes a new `clone` helper, updates to the core `AIOFile` class, and corresponding tests and documentation.

**New file cloning feature:**

* Added a `clone` helper function and `FileIOCloner` class to `aiofile.utils`, allowing users to create independent file-like clones from an existing file object. This enables concurrent operations with separate offsets on the same file descriptor.
* Updated the public API in `aiofile/__init__.py` to export `clone` and `FileIOCloner`. [[1]](diffhunk://#diff-72ab4059288ee91d7149fdb6fcb38c696f50a93bee06cdc8aebf1b236d673e84L3-R4) [[2]](diffhunk://#diff-72ab4059288ee91d7149fdb6fcb38c696f50a93bee06cdc8aebf1b236d673e84R15) [[3]](diffhunk://#diff-72ab4059288ee91d7149fdb6fcb38c696f50a93bee06cdc8aebf1b236d673e84R25)

**Core class enhancements:**

* Modified the `AIOFile` class to support reference counting for clones, ensuring the file is only closed when all clones are released. Added a `clone()` async method and internal locking for thread safety. [[1]](diffhunk://#diff-215f902376b66188ad57674775fe016e576ca950e57e1fd24064431cdd2adbdcR142-R143) [[2]](diffhunk://#diff-215f902376b66188ad57674775fe016e576ca950e57e1fd24064431cdd2adbdcR193-R208)

**Documentation:**

* Added a new section to `README.md` explaining the `clone` helper, including a practical example and caveats for Windows users.

**Testing:**

* Added new tests in `tests/test_aio.py` to verify the behavior of file cloning, including correct reading, offset handling, and reference-counted closing. [[1]](diffhunk://#diff-614def4a76e1cf37e5de137c397dc920548ca7560707013fc38f3aea84603652L16-R16) [[2]](diffhunk://#diff-614def4a76e1cf37e5de137c397dc920548ca7560707013fc38f3aea84603652R632-R678)