### PR TITLE
Use `Project-URL` metadata field instead of deprecated `Home-page`

### DIFF
--- a/aiofile/version.py
+++ b/aiofile/version.py
@@ -8,6 +8,10 @@ __version__ = package_metadata["Version"]
 author_info = [(package_metadata["Author"], package_metadata["Author-email"])]
 package_info = package_metadata["Summary"]
 package_license = package_metadata["License"]
-project_home = package_metadata["Home-page"]
+project_home = next(
+    url.split(",")[1].strip()
+    for url in package_metadata.get_all("Project-URL", [])
+    if "homepage" in url.lower()
+)
 team_email = package_metadata["Author-email"]
 version_info = tuple(map(int, __version__.split(".")))


### PR DESCRIPTION
Fixes: https://github.com/mosquito/aiofile/issues/97  
See-Also: https://peps.python.org/pep-0753/  
See-Also: https://github.com/pypa/packaging-problems/issues/606