### PR TITLE
Include tests in sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ classifiers = [
 packages = [
     { include = "aiofile" },
 ]
+include = [
+    { path = "tests", format = "sdist" }
+]
 
 [tool.poetry.dependencies]
 python = ">=3.8,<4"


### PR DESCRIPTION
As of now tests are not included in the sdist package and there are no tags for the latest versions in the git repository making it impossible for distro maintainers to properly test this project in the packages.