### PR TITLE
Fix KeyError when reading package metadata on Python 3.14

### DIFF
--- a/aiofile/version.py
+++ b/aiofile/version.py
@@ -1,17 +1,26 @@
 import importlib.metadata
+from email.utils import parseaddr
 
 
 package_metadata = importlib.metadata.metadata("aiofile")
 
-__author__ = package_metadata["Author"]
+_author_email_raw = package_metadata.get("Author-email", "")
+_author_name, _author_email_addr = parseaddr(_author_email_raw)
+
+__author__ = package_metadata.get("Author", _author_name)
 __version__ = package_metadata["Version"]
-author_info = [(package_metadata["Author"], package_metadata["Author-email"])]
-package_info = package_metadata["Summary"]
-package_license = package_metadata["License"]
-project_home = next(
-    url.split(",")[1].strip()
-    for url in package_metadata.get_all("Project-URL", [])
-    if "homepage" in url.lower()
+author_info = [(__author__, _author_email_addr or _author_email_raw)]
+package_info = package_metadata.get("Summary", "")
+package_license = package_metadata.get(
+    "License-Expression", package_metadata.get("License", ""),
 )
-team_email = package_metadata["Author-email"]
+project_home = next(
+    (
+        url.split(",")[1].strip()
+        for url in package_metadata.get_all("Project-URL", [])
+        if "homepage" in url.lower()
+    ),
+    "",
+)
+team_email = _author_email_addr or _author_email_raw
 version_info = tuple(map(int, __version__.split(".")))


### PR DESCRIPTION
## Summary

- Fix `KeyError: 'Author'` when running on Python 3.14 (and potentially other environments where metadata format differs)
- PEP 621 `authors` table in `pyproject.toml` generates `Author-email: Name <email>` but no standalone `Author` field — use `.get()` with fallback that parses the name from `Author-email`
- Similarly, `license = "Apache-2.0"` (SPDX string) maps to `License-Expression`, not `License` — try both fields
- Add a default to the `project_home` generator expression so it doesn't raise `StopIteration` if no homepage URL is found

## Context

This causes test collection failures in downstream projects on Python 3.14, e.g.:
https://github.com/home-assistant/core/actions/runs/25948577399/job/76281944514?pr=170851