### PR TITLE
Add multi-library throughput benchmark

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+benchmark/results/*.png filter=lfs diff=lfs merge=lfs -text
+benchmark/results/*.gz filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -475,3 +475,11 @@ async def main():
 
 asyncio.run(main())
 ```
+
+## Benchmark
+
+![aiofile benchmark: throughput by library, backend and concurrency](https://media.githubusercontent.com/media/mosquito/aiofile/master/benchmark/results/aiofile-bench-report.png)
+
+stdlib, `aiofile` (every `caio` backend), `aiofiles`, `aiomisc.io` — linear/random
+block order, read/write, buffered/`O_DIRECT`, sequential/concurrent, content-verified.
+Tool, methodology and raw data: [`benchmark/`](benchmark/).

--- a/benchmark/.gitignore
+++ b/benchmark/.gitignore
@@ -1,0 +1,3 @@
+./bench-data/
+*.log
+*.tsv

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,117 @@
+# aiofile benchmark
+
+Compares `aiofile` (across every `caio` backend available on this platform)
+against the stdlib, `aiofiles` and `aiomisc.io`. **Linux only.**
+
+This is a separate uv project on purpose, so its dependencies don't leak
+into the main package.
+
+## What it measures
+
+Every axis combination gets its own freshly created, correctly sized temp
+file inside `--dir` -- never a fixed path, never reused across passes --
+so results aren't polluted by page-cache state or writeback left behind
+by an earlier library/mode/pattern/round:
+
+- **library**: stdlib, `aiofile`, `aiofiles`, `aiomisc.io`
+- **backend** (`aiofile` only): every entry in `caio.variants_asyncio` on
+  this platform (e.g. `linux_uring`, `linux_aio`, `thread_aio`,
+  `python_aio`), each via an explicitly constructed `AsyncioContext`
+  passed as `AIOFile(..., context=...)` -- not the `CAIO_IMPL` environment
+  variable, so every backend runs in one process, one invocation
+- **mode**: buffered, or `O_DIRECT`
+- **pattern**: linear or random block order
+- **op**: read or write
+- **concurrency**: one worker, or `--concurrency` workers -- all against
+  the *same* open handle, not one handle each
+
+`O_DIRECT` is exercised for stdlib only, via `os.pwritev`/`os.preadv` into
+a caller-owned page-aligned buffer, so alignment is preserved end to end.
+`aiofile` is excluded from the `O_DIRECT` cases: `AIOFile.read_bytes` has
+`caio` allocate the destination buffer with no alignment guarantee, and
+there is no public API to supply one instead (see aiofile issue #100).
+`aiofiles`/`aiomisc.io` open files through the stdlib `open()`, which has
+no way to request `O_DIRECT` at all.
+
+Every read and write is content-verified: the first 8 bytes of each block
+are tagged with its offset on write and checked on read, *after* the
+timed region stops so verification cost isn't counted as I/O time. A
+mismatch or short read/write aborts the run with a traceback instead of
+silently producing a bad number.
+
+The timed metric is operation-completion time, not durable-write time: it
+stops as soon as the read/write calls return, before the session's
+`close()` (which for a writable `AIOFile` runs `fdsync`, and for a
+buffered Python file object may flush on close). Two libraries closing
+differently isn't reflected in the numbers.
+
+## Running
+
+```sh
+cd benchmark
+uv run python bench.py > results.tsv
+```
+
+stdout is *only* the TSV header and data rows -- nothing else, so it's
+safe to redirect straight to a file. Progress and environment info
+(Python/kernel version, which `caio` backends were found, effective
+concurrency) go to stderr via `logging`, not stdout.
+
+Flags (see `--help`): `--file-size`, `--block-size` (must be a multiple
+of 4096, the `O_DIRECT` alignment this script assumes), `--concurrency`,
+`--rounds`, `--dir`, `--max-requests` and `--deferred` (passed to every
+`caio` `AsyncioContext`).
+
+## Output
+
+One raw row per `(library, backend, mode, pattern, op, concurrency,
+round)` -- every round kept separate, nothing averaged or min'd. Compute
+mean/stdev/quantiles/whatever downstream from the TSV; this script
+doesn't rank or aggregate anything itself.
+
+| column | meaning |
+|---|---|
+| `library` | `stdlib`, `aiofile`, `aiofiles`, `aiomisc` |
+| `backend` | `caio` backend name for `aiofile` rows, `n/a` otherwise |
+| `mode` | `buffered` or `direct` |
+| `pattern` | `linear` or `random` block order |
+| `op` | `write` or `read` |
+| `concurrency` | worker count for this pass |
+| `round` | 0-based round index |
+| `file_size`, `block_size` | bytes |
+| `seconds` | wall-clock time for the whole pass (all workers, all blocks) |
+| `mib_per_sec` | `file_size` / `seconds`, in MiB/s |
+
+## Reading the results
+
+- `stdlib` and `aiofile` speed up under concurrency (`x1` vs `xN`)
+  because both use true positional I/O (`os.pwritev`/`preadv`,
+  `read_bytes`/`write_bytes` with an explicit offset) against one shared
+  handle with no cursor to fight over. This is a measured outcome, not a
+  guarantee -- it depends on the `caio` backend, executor/pool limits,
+  filesystem, and workload size.
+- `aiofiles`/`aiomisc.io` don't: their handles carry a single seek
+  cursor, so concurrent access to the *same* handle has to be serialized
+  with a lock in this script -- there's no positional API to use instead.
+  Opening a separate handle per worker would sidestep that, but then
+  you're no longer measuring access to the same open file.
+- Don't average across `aiofile` backends into one "aiofile speed".
+  `linux_uring` vs `linux_aio` compares two native kernel submission
+  mechanisms; `thread_aio` vs `python_aio` compares two blocking-thread
+  adapters; native vs thread-based compares different execution models
+  entirely. Compare backends pairwise for a specific question (e.g. "which
+  minimizes per-op overhead at this block size"), not as one ranking.
+
+None of this is a universal ranking. Results depend on the OS, filesystem,
+storage device, and kernel. If you're benchmarking the `caio` backends
+themselves rather than the libraries built on top, see `caio`'s own
+`benchmark/` directory.
+
+## Plotting
+
+`plot_results.py` turns a TSV into a PNG report (grouped throughput bars
+per op/pattern, plus a concurrency-speedup chart):
+
+```sh
+uv run --with matplotlib --with numpy --with pillow python plot_results.py results.tsv
+```

--- a/benchmark/bench.py
+++ b/benchmark/bench.py
@@ -1,0 +1,407 @@
+"""
+Single-file read/write benchmark: stdlib, aiofile (across every available
+caio backend), aiofiles, aiomisc.io.
+
+Linux only. Every timed pass gets its own freshly created, correctly
+sized temp file inside --dir (never a fixed path, never reused across
+passes) so results aren't polluted by page-cache state or writeback left
+behind by an earlier library/mode/pattern. Axes: linear vs random block
+order, read vs write, buffered vs O_DIRECT, sequential vs concurrent
+workers against one shared open handle.
+
+O_DIRECT is exercised for stdlib only, via os.pwritev/os.preadv into a
+caller-owned page-aligned buffer -- alignment is preserved end to end.
+aiofile is excluded from O_DIRECT: AIOFile.read_bytes has caio allocate
+the destination buffer with no alignment guarantee, and there is no
+public API to supply one (see aiofile issue #100). aiofiles/aiomisc.io
+open files through the stdlib `open()` with no way to pass O_DIRECT at
+all.
+
+aiofile is benchmarked once per caio backend available on this platform
+(`caio.variants_asyncio`) using an explicitly constructed context per
+backend, not the CAIO_IMPL environment variable -- so all backends run
+in one process, one script invocation.
+
+Every read/write is content-verified: the first 8 bytes of each block
+are tagged with its offset on write and checked on read, after the timed
+region so verification cost isn't counted as I/O time. A mismatch aborts
+the run with a traceback instead of silently producing a bad number.
+
+This script only writes: a TSV header, then one raw row per (library,
+backend, mode, pattern, op, concurrency, round) to stdout -- no
+aggregation, no ranking. Compute stdev/quantiles/whatever downstream.
+Progress and environment info go to stderr via `logging`.
+"""
+import argparse
+import asyncio
+import logging
+import mmap
+import os
+import platform
+import random
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import aiofiles
+import aiomisc.io as aiomisc_io
+import caio
+
+from aiofile import AIOFile
+
+log = logging.getLogger("bench")
+
+DIRECT_ALIGN = 4096
+
+
+def aligned_buffer(size):
+    # mmap'd memory is page-aligned, which O_DIRECT needs; a plain
+    # bytes/bytearray has no such guarantee.
+    buf = mmap.mmap(-1, size)
+    buf[:] = os.urandom(size)
+    return buf
+
+
+def tag(buffer, offset):
+    buffer[0:8] = offset.to_bytes(8, "little")
+
+
+def check_tag(data, offset, block_size, where):
+    if len(data) != block_size:
+        raise RuntimeError(
+            f"{where}: short read {len(data)} != {block_size} "
+            f"at offset {offset}",
+        )
+    got = int.from_bytes(data[:8], "little")
+    if got != offset:
+        raise RuntimeError(
+            f"{where}: content mismatch at offset {offset}: tag={got}",
+        )
+
+
+def populate_file(path, file_size, block_size):
+    """Untimed setup for read passes: write a correctly tagged block at
+    every offset so the timed read has real, checkable data to see."""
+    fd = os.open(str(path), os.O_RDWR)
+    try:
+        buf = aligned_buffer(block_size)
+        for offset in range(0, file_size, block_size):
+            tag(buf, offset)
+            os.pwrite(fd, buf, offset)
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+# -- sessions: one already-open handle to a file, write_at/read_at must
+# -- be safe to call concurrently from multiple tasks against it --------
+
+class Session:
+    def __init__(self, path, direct):
+        self.path = path
+        self.direct = direct
+
+    async def write_at(self, offset, buffer):
+        raise NotImplementedError
+
+    async def read_at(self, offset, buffer, size):
+        raise NotImplementedError
+
+
+class StdlibSession(Session):
+    """pwritev/preadv into a caller-owned buffer: correct under O_DIRECT
+    (alignment preserved end to end, unlike pwrite/pread which can't take
+    a caller destination buffer for reads) and safe to call concurrently
+    from multiple threads against one fd, since neither touches the fd's
+    file position."""
+
+    async def __aenter__(self):
+        flags = os.O_RDWR | os.O_CREAT
+        if self.direct:
+            flags |= os.O_DIRECT
+        self.fd = os.open(str(self.path), flags, 0o644)
+        return self
+
+    async def __aexit__(self, *exc):
+        os.close(self.fd)
+
+    async def write_at(self, offset, buffer):
+        return await asyncio.to_thread(os.pwritev, self.fd, [buffer], offset)
+
+    async def read_at(self, offset, buffer, size):
+        n = await asyncio.to_thread(os.preadv, self.fd, [buffer], offset)
+        return bytes(buffer[:n])
+
+
+class AIOFileSession(Session):
+    """Buffered only -- see module docstring for why aiofile is excluded
+    from the O_DIRECT cases. read_bytes/write_bytes take an explicit
+    offset and AIOFile keeps no internal cursor, so the same instance can
+    be hit concurrently with no locking of our own."""
+
+    def __init__(self, path, context):
+        super().__init__(path, direct=False)
+        self.context = context
+
+    async def __aenter__(self):
+        self.afp = AIOFile(self.path, "rb+", context=self.context)
+        await self.afp.open()
+        return self
+
+    async def __aexit__(self, *exc):
+        await self.afp.close()
+
+    async def write_at(self, offset, buffer):
+        return await self.afp.write_bytes(buffer, offset)
+
+    async def read_at(self, offset, buffer, size):
+        return await self.afp.read_bytes(size, offset)
+
+
+class AiofilesSession(Session):
+    """aiofiles wraps one stdlib file object with one seek cursor, so
+    concurrent access to a single handle has to be serialized by hand --
+    there's no positional read/write in its public API."""
+
+    def __init__(self, path):
+        super().__init__(path, direct=False)
+
+    async def __aenter__(self):
+        self.fp = await aiofiles.open(self.path, "rb+")
+        self.lock = asyncio.Lock()
+        return self
+
+    async def __aexit__(self, *exc):
+        await self.fp.close()
+
+    async def write_at(self, offset, buffer):
+        async with self.lock:
+            await self.fp.seek(offset)
+            return await self.fp.write(buffer)
+
+    async def read_at(self, offset, buffer, size):
+        async with self.lock:
+            await self.fp.seek(offset)
+            return await self.fp.read(size)
+
+
+class AiomiscSession(Session):
+    """Same limitation as aiofiles: one seek cursor per handle."""
+
+    def __init__(self, path):
+        super().__init__(path, direct=False)
+
+    async def __aenter__(self):
+        self.fp = aiomisc_io.async_open(self.path, "rb+")
+        await self.fp.open()
+        self.lock = asyncio.Lock()
+        return self
+
+    async def __aexit__(self, *exc):
+        await self.fp.close()
+
+    async def write_at(self, offset, buffer):
+        async with self.lock:
+            await self.fp.seek(offset)
+            return await self.fp.write(buffer)
+
+    async def read_at(self, offset, buffer, size):
+        async with self.lock:
+            await self.fp.seek(offset)
+            return await self.fp.read(size)
+
+
+async def run_pass(session_cm, offsets, block_size, write, concurrency):
+    async with session_cm as session:
+        buffers = [aligned_buffer(block_size) for _ in range(concurrency)]
+        chunks = [offsets[i::concurrency] for i in range(concurrency)]
+
+        async def worker(chunk, buffer):
+            collected = []
+            for offset in chunk:
+                if write:
+                    tag(buffer, offset)
+                    written = await session.write_at(offset, buffer)
+                    collected.append((offset, written))
+                else:
+                    data = await session.read_at(offset, buffer, block_size)
+                    collected.append((offset, bytes(data)))
+            return collected
+
+        start = time.monotonic()
+        worker_results = await asyncio.gather(
+            *(worker(chunk, buffer) for chunk, buffer in zip(chunks, buffers)),
+        )
+        elapsed = time.monotonic() - start
+
+        # Verification happens after the timer stops so it isn't counted
+        # as I/O time -- see module docstring.
+        for collected in worker_results:
+            for offset, value in collected:
+                if write:
+                    if value != block_size:
+                        raise RuntimeError(
+                            f"write: short write {value} != {block_size} "
+                            f"at offset {offset}",
+                        )
+                else:
+                    check_tag(value, offset, block_size, "read")
+
+        return elapsed
+
+
+def build_participants(args, backend_contexts):
+    participants = [
+        (
+            "stdlib", "n/a",
+            lambda path, direct: StdlibSession(path, direct),
+            True,
+        ),
+    ]
+    for name, ctx in backend_contexts.items():
+        participants.append((
+            "aiofile", name,
+            (lambda path, direct, ctx=ctx: AIOFileSession(path, ctx)),
+            False,
+        ))
+    participants.append(
+        ("aiofiles", "n/a", lambda path, direct: AiofilesSession(path), False),
+    )
+    participants.append(
+        ("aiomisc", "n/a", lambda path, direct: AiomiscSession(path), False),
+    )
+    return participants
+
+
+async def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--file-size", type=int, default=8 * 1024 * 1024)
+    parser.add_argument("--block-size", type=int, default=4096)
+    parser.add_argument("--concurrency", type=int, default=8)
+    parser.add_argument("--rounds", type=int, default=1)
+    parser.add_argument("--dir", type=Path, default=Path("./bench-data"))
+    parser.add_argument(
+        "--max-requests", type=int, default=None,
+        help="caio context max_requests (default: backend default)",
+    )
+    parser.add_argument(
+        "--deferred", action="store_true",
+        help="submit aiofile/caio operations in deferred (batched) mode",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        stream=sys.stderr, level=logging.INFO, format="%(message)s",
+    )
+
+    if min(args.file_size, args.block_size, args.concurrency, args.rounds) <= 0:
+        parser.error(
+            "--file-size/--block-size/--concurrency/--rounds must be positive",
+        )
+    if args.file_size % args.block_size:
+        parser.error("--file-size must be a multiple of --block-size")
+    if args.block_size % DIRECT_ALIGN:
+        parser.error(f"--block-size must be a multiple of {DIRECT_ALIGN}")
+
+    args.dir.mkdir(exist_ok=True)
+
+    block_count = args.file_size // args.block_size
+    concurrency = min(args.concurrency, block_count)
+    if concurrency != args.concurrency:
+        log.info(
+            "concurrency capped %d -> %d (only %d blocks)",
+            args.concurrency, concurrency, block_count,
+        )
+
+    linear = list(range(0, args.file_size, args.block_size))
+    random_order = linear[:]
+    random.Random(0).shuffle(random_order)
+    patterns = {"linear": linear, "random": random_order}
+
+    has_direct = hasattr(os, "O_DIRECT")
+    if not has_direct:
+        log.info("O_DIRECT unavailable (not Linux?), skipping direct cases")
+
+    backend_contexts = {
+        module.__name__.rsplit(".", 1)[-1].removesuffix("_asyncio"):
+            module.AsyncioContext(
+                max_requests=args.max_requests, deferred=args.deferred,
+            )
+        for module in caio.variants_asyncio
+    }
+    log.info(
+        "env: python=%s system=%s release=%s caio_backends=%s "
+        "max_requests=%s deferred=%s",
+        platform.python_version(), platform.system(), platform.release(),
+        ",".join(backend_contexts) or "none", args.max_requests, args.deferred,
+    )
+
+    participants = build_participants(args, backend_contexts)
+
+    columns = (
+        "library", "backend", "mode", "pattern", "op", "concurrency",
+        "round", "file_size", "block_size", "seconds", "mib_per_sec",
+    )
+    print("\t".join(columns), flush=True)
+
+    try:
+        for entry in participants:
+            library, backend_name, make_session, direct_capable = entry
+            direct_ok = direct_capable and has_direct
+            modes = [False, True] if direct_ok else [False]
+            for direct in modes:
+                mode_label = "direct" if direct else "buffered"
+                for pattern_name, offsets in patterns.items():
+                    for op, write in (("write", True), ("read", False)):
+                        for pass_concurrency in sorted({1, concurrency}):
+                            for round_index in range(args.rounds):
+                                fd, tmp_name = tempfile.mkstemp(
+                                    dir=args.dir, prefix="bench-",
+                                )
+                                os.ftruncate(fd, args.file_size)
+                                os.close(fd)
+                                path = Path(tmp_name)
+                                try:
+                                    if not write:
+                                        await asyncio.to_thread(
+                                            populate_file, path,
+                                            args.file_size, args.block_size,
+                                        )
+                                    session_cm = make_session(path, direct)
+                                    seconds = await run_pass(
+                                        session_cm, offsets, args.block_size,
+                                        write, pass_concurrency,
+                                    )
+                                finally:
+                                    path.unlink(missing_ok=True)
+
+                                mib_per_sec = (
+                                    (args.file_size / (1024 * 1024)) / seconds
+                                )
+                                log.info(
+                                    "%s/%s %s %s %s x%d round %d: %.3fs",
+                                    library, backend_name, mode_label,
+                                    pattern_name, op, pass_concurrency,
+                                    round_index, seconds,
+                                )
+                                row = (
+                                    library, backend_name, mode_label,
+                                    pattern_name, op, pass_concurrency,
+                                    round_index, args.file_size,
+                                    args.block_size, seconds, mib_per_sec,
+                                )
+                                print(
+                                    "\t".join(str(v) for v in row),
+                                    flush=True,
+                                )
+    finally:
+        for ctx in backend_contexts.values():
+            ctx.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/benchmark/plot_results.py
+++ b/benchmark/plot_results.py
@@ -1,0 +1,188 @@
+"""
+Plot aiofile benchmark results (bench.py's TSV output).
+
+Usage:
+  uv run --with matplotlib --with numpy --with pillow python plot_results.py \
+      [results.tsv]
+
+Defaults to results/aiofile-bench-results.tsv next to this script. Produces
+aiofile-bench-report.png in the same directory as the input TSV.
+"""
+import csv
+import pathlib
+import sys
+from collections import defaultdict
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+from PIL import Image
+
+SCRIPT_DIR = pathlib.Path(__file__).parent
+DEFAULT_TSV = SCRIPT_DIR / "results" / "aiofile-bench-results.tsv"
+
+# (library, backend, mode, display label)
+PARTICIPANTS = [
+    ("stdlib", "n/a", "buffered", "stdlib\nbuffered"),
+    ("stdlib", "n/a", "direct", "stdlib\nO_DIRECT"),
+    ("aiofile", "linux_uring", "buffered", "aiofile\nlinux_uring"),
+    ("aiofile", "linux_aio", "buffered", "aiofile\nlinux_aio"),
+    ("aiofile", "thread_aio", "buffered", "aiofile\nthread_aio"),
+    ("aiofile", "python_aio", "buffered", "aiofile\npython_aio"),
+    ("aiofiles", "n/a", "buffered", "aiofiles"),
+    ("aiomisc", "n/a", "buffered", "aiomisc"),
+]
+
+CONC_COLORS = {1: "#3498db", 8: "#e74c3c", 16: "#2ecc71", 32: "#f39c12"}
+
+
+def load_rows(path):
+    with path.open(newline="") as fp:
+        return list(csv.DictReader(fp, delimiter="\t"))
+
+
+def group_by_mib(rows):
+    """(library, backend, mode, pattern, op, concurrency) -> [mib_per_sec, ...]"""
+    result = defaultdict(list)
+    for r in rows:
+        key = (
+            r["library"], r["backend"], r["mode"], r["pattern"], r["op"],
+            int(r["concurrency"]),
+        )
+        result[key].append(float(r["mib_per_sec"]))
+    return result
+
+
+def apply_style(ax, ylabel, title):
+    ax.set_ylabel(ylabel, fontsize=9)
+    ax.set_title(title, fontsize=10, fontweight="bold")
+    ax.grid(True, axis="y", linestyle="--", alpha=0.4)
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+
+
+def plot_throughput_grid(rows, out_path):
+    grouped = group_by_mib(rows)
+    conc_levels = sorted({int(r["concurrency"]) for r in rows})
+    ops = ["write", "read"]
+    patterns = ["linear", "random"]
+
+    fig, axes = plt.subplots(
+        len(ops), len(patterns),
+        figsize=(6.5 * len(patterns), 4.6 * len(ops)),
+    )
+    x = np.arange(len(PARTICIPANTS))
+    bar_w = 0.8 / len(conc_levels)
+
+    for row_i, op in enumerate(ops):
+        for col_i, pattern in enumerate(patterns):
+            ax = axes[row_i][col_i]
+            for ci, conc in enumerate(conc_levels):
+                xs, means, lo, hi = [], [], [], []
+                for i, p in enumerate(PARTICIPANTS):
+                    key = (p[0], p[1], p[2], pattern, op, conc)
+                    if key not in grouped:
+                        continue
+                    vals = grouped[key]
+                    m = float(np.mean(vals))
+                    xs.append(i)
+                    means.append(m)
+                    lo.append(m - min(vals))
+                    hi.append(max(vals) - m)
+                if not xs:
+                    continue
+                offset = (ci - (len(conc_levels) - 1) / 2) * bar_w
+                ax.bar(
+                    np.array(xs) + offset, means, width=bar_w * 0.9,
+                    color=CONC_COLORS.get(conc, "#7f8c8d"), label=f"x{conc}",
+                    yerr=[lo, hi], capsize=3,
+                    error_kw={"linewidth": 1, "alpha": 0.6},
+                )
+
+            ax.set_yscale("log")
+            apply_style(ax, "MiB/s (log, min-max whiskers)", f"{op} - {pattern}")
+            ax.set_xticks(x)
+            ax.set_xticklabels([p[3] for p in PARTICIPANTS], fontsize=7.5)
+            ax.legend(fontsize=8, framealpha=0.7, title="concurrency")
+
+    fig.suptitle(
+        "aiofile benchmark -- throughput by participant",
+        fontsize=13, fontweight="bold",
+    )
+    fig.tight_layout(rect=(0, 0, 1, 0.96))
+    fig.savefig(out_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    print(f"saved {out_path}")
+
+
+def plot_concurrency_speedup(rows, out_path):
+    grouped = group_by_mib(rows)
+    conc_levels = sorted({int(r["concurrency"]) for r in rows})
+    if len(conc_levels) < 2:
+        return
+    lo_conc, hi_conc = conc_levels[0], conc_levels[-1]
+
+    fig, ax = plt.subplots(figsize=(9, 4.6))
+    x = np.arange(len(PARTICIPANTS))
+    speedups, present = [], []
+    for i, p in enumerate(PARTICIPANTS):
+        lo_key = (p[0], p[1], p[2], "linear", "write", lo_conc)
+        hi_key = (p[0], p[1], p[2], "linear", "write", hi_conc)
+        if lo_key not in grouped or hi_key not in grouped:
+            continue
+        lo_mean = float(np.mean(grouped[lo_key]))
+        hi_mean = float(np.mean(grouped[hi_key]))
+        speedups.append(hi_mean / lo_mean if lo_mean else 0)
+        present.append(i)
+
+    colors = ["#2ecc71" if s >= 1 else "#e74c3c" for s in speedups]
+    ax.bar(present, speedups, color=colors, width=0.6)
+    ax.axhline(1.0, color="#555555", linewidth=1, linestyle="-")
+    apply_style(
+        ax, f"x{hi_conc} / x1 throughput ratio",
+        f"Concurrency speedup (linear write, x{lo_conc} -> x{hi_conc})",
+    )
+    ax.set_xticks(x)
+    ax.set_xticklabels([p[3] for p in PARTICIPANTS], fontsize=7.5)
+
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+    print(f"saved {out_path}")
+
+
+def combine_vertically(top_path, bottom_path, out_path):
+    with Image.open(top_path) as top, Image.open(bottom_path) as bottom:
+        width = max(top.width, bottom.width)
+        height = top.height + bottom.height
+        combined = Image.new("RGB", (width, height), "white")
+        combined.paste(top.convert("RGB"), (0, 0))
+        combined.paste(bottom.convert("RGB"), (0, top.height))
+        combined.save(out_path)
+    print(f"combined {out_path}")
+
+
+def main():
+    tsv_path = pathlib.Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_TSV
+    if not tsv_path.exists():
+        raise SystemExit(f"Benchmark TSV not found: {tsv_path}")
+
+    rows = load_rows(tsv_path)
+    out_dir = tsv_path.parent
+    throughput_png = out_dir / "throughput_by_participant.png"
+    speedup_png = out_dir / "concurrency_speedup.png"
+    report_png = out_dir / "aiofile-bench-report.png"
+
+    plot_throughput_grid(rows, throughput_png)
+    plot_concurrency_speedup(rows, speedup_png)
+    combine_vertically(throughput_png, speedup_png, report_png)
+    throughput_png.unlink()
+    speedup_png.unlink()
+
+    print(f"\nReport saved to {report_png.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/pyproject.toml
+++ b/benchmark/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "aiofile-benchmark"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "aiofile",
+    "aiofiles",
+    "aiomisc",
+]
+
+[tool.uv.sources]
+aiofile = { path = "..", editable = true }

--- a/benchmark/results/aiofile-bench-report.png
+++ b/benchmark/results/aiofile-bench-report.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88d02d3a0f12c4442ff030db952bda86ac990a78e95e165b16d110826e325fa9
+size 176637

--- a/benchmark/results/aiofile-bench-results.log.gz
+++ b/benchmark/results/aiofile-bench-results.log.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:64ab7cfef9250478f56f559c442795a92419c731deba1c088522b3df710fc074
+size 1986

--- a/benchmark/results/aiofile-bench-results.tsv.gz
+++ b/benchmark/results/aiofile-bench-results.tsv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a4ee2867b1f3df6b337ab11c83bad30b3ad18961bfcbea68f3df4fb3e5b03c6f
+size 7950

--- a/benchmark/uv.lock
+++ b/benchmark/uv.lock
@@ -1,0 +1,139 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "aiofile"
+version = "3.9.0"
+source = { editable = "../" }
+dependencies = [
+    { name = "caio" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "caio", specifier = "~=0.12.0" }]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "aiomisc-pytest", specifier = ">=2.0.0,<3" },
+    { name = "coveralls", specifier = "<4" },
+    { name = "markdown-pytest", specifier = ">=0.6.5,<0.7" },
+    { name = "pytest", specifier = ">=8.4" },
+    { name = "pytest-cov", specifier = ">=5.0.0,<6" },
+    { name = "ruff", specifier = ">=0.15" },
+    { name = "ty", specifier = ">=0.0.37" },
+]
+
+[[package]]
+name = "aiofile-benchmark"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "aiofile" },
+    { name = "aiofiles" },
+    { name = "aiomisc" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiofile", editable = "../" },
+    { name = "aiofiles" },
+    { name = "aiomisc" },
+]
+
+[[package]]
+name = "aiofiles"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/c3/534eac40372d8ee36ef40df62ec129bee4fdb5ad9706e58a29be53b2c970/aiofiles-25.1.0.tar.gz", hash = "sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2", size = 46354, upload-time = "2025-10-09T20:51:04.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl", hash = "sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695", size = 14668, upload-time = "2025-10-09T20:51:03.174Z" },
+]
+
+[[package]]
+name = "aiomisc"
+version = "18.0.26"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiothreads" },
+    { name = "colorlog" },
+    { name = "logging-journald", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/5c/fa97a5bc97485a3c2556e5d0eda206ffba9d55a2757663e5b3d44695ecb6/aiomisc-18.0.26.tar.gz", hash = "sha256:c2c4e5e372d01ccc8748c2a5673095e4a99c754309400e756658c1b8b3225138", size = 506836, upload-time = "2026-07-10T06:54:23.118Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/c3/5ce937640272a0322967494085061d36f80b23a5cf381d512864f1c83874/aiomisc-18.0.26-py3-none-any.whl", hash = "sha256:15c09091a90461ad3dbf6a0630689ce301cb9697ad6206d9b869304daaae36a1", size = 96716, upload-time = "2026-07-10T06:54:21.678Z" },
+]
+
+[[package]]
+name = "aiothreads"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/08/7e65a6bf0baa504587cb28fd4430778ddbdf8b7ccd0f5d92ddd156799cdf/aiothreads-1.1.1.tar.gz", hash = "sha256:cb2fcecc5177251c014d89fb5bf52a5b3acf9b64e8ef5e35a7981f196d610684", size = 116313, upload-time = "2026-03-03T17:25:57.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/6e/53744d2d9b7856c5f8bd8a7c6958edcb70b755a2cad29188a9784c61a8f5/aiothreads-1.1.1-py3-none-any.whl", hash = "sha256:2c94d9cb364a0b4ee65845691049d06f5d43751766b21550a063f3d84347d640", size = 22852, upload-time = "2026-03-03T17:25:55.678Z" },
+]
+
+[[package]]
+name = "caio"
+version = "0.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/c8/82b3c760141a1076408164b03e8789b51809add6aecd48aa9d7651cf6b59/caio-0.12.2.tar.gz", hash = "sha256:87a67c0dccc60e432888bd532ec504b66e124a5d8b391aab894583b55abd39ea", size = 80927, upload-time = "2026-08-04T14:43:33.726Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/e9/c346d656b2f3626ef726aaac1c5ea58a981757cbed62087a9e81eaa4b09f/caio-0.12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a2a7f0fa3b49f219f09705717c73a618eecbb3d697701e20abb4771d17e2bbcf", size = 84555, upload-time = "2026-08-04T14:42:56.84Z" },
+    { url = "https://files.pythonhosted.org/packages/84/60/0b99da0d1345c0c1f9bde58ae96527b54b4aae32c2b6e74dcef514f7fa9c/caio-0.12.2-cp311-cp311-manylinux_2_34_aarch64.whl", hash = "sha256:1b04358ef65bd03d9c34d7b028efb422593b07485da82d6c5439f8c5dea35668", size = 196508, upload-time = "2026-08-04T14:42:58.074Z" },
+    { url = "https://files.pythonhosted.org/packages/92/7e/7eb5a9ab97cfa5500a2cff8444e16e183aab6473912ac37d8bf9de283337/caio-0.12.2-cp311-cp311-manylinux_2_34_x86_64.whl", hash = "sha256:e1253743841b0864bfd6827e496fea4591bb3999ec1c003e57de65370e2d9031", size = 192985, upload-time = "2026-08-04T14:42:59.404Z" },
+    { url = "https://files.pythonhosted.org/packages/92/13/308773ae27f33bc141720ded63216c9a115f5838c1e341d2d37c2b051281/caio-0.12.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:bd94522714af3fd806093bdd10f3175f1c42c5ee72dda975b8b35b55c3400147", size = 194087, upload-time = "2026-08-04T14:43:00.645Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/8b/08814adc89f2c7612da9c2f17d962626bf59eb3b4dd715ea8198ccecb66c/caio-0.12.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a857d06308dc4428b760f9430350b3847f4c62ad0e79e635215f7cc97f7adcc9", size = 192586, upload-time = "2026-08-04T14:43:02.388Z" },
+    { url = "https://files.pythonhosted.org/packages/60/bc/b62bf048a6e11870291a24319ed027bdf658df9ba77d1ad762aa138e066b/caio-0.12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2097cc0d19fa95e8d55aad770597bb0f76e4f70ed48278c965aa7c5b0b8c3bf5", size = 84702, upload-time = "2026-08-04T14:43:03.946Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/be/b40d55d793afcfa5bcdb32ade9289d9588e14e3026c2c87522e303cc6e8c/caio-0.12.2-cp312-cp312-manylinux_2_34_aarch64.whl", hash = "sha256:2122dccbd1959b922543fc9f8a9d2af47bd5b59190d1ece2445d3d1b4d1be45f", size = 198292, upload-time = "2026-08-04T14:43:05.238Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/02/9bd2bca72bfa478337618eae88942c43c891ae225e11baeae275e5e5c6ab/caio-0.12.2-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:107e56554c179749de9440e1b5e5a19813572eebf3166e9dc3e5228b16966beb", size = 196207, upload-time = "2026-08-04T14:43:06.494Z" },
+    { url = "https://files.pythonhosted.org/packages/48/9b/65f95efdd68b50b7a9f2555c93d9edc7da7aa5ae5e153163c41cf6fd5cd9/caio-0.12.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:adc7785e61ff7cf372318f67ec65617eaa06975e20da177522665dca8be6ea5d", size = 195748, upload-time = "2026-08-04T14:43:07.893Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/16/6a5c010ca435a5184d11ca350874694ac19db249560126dc8df0f25791ce/caio-0.12.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:07942d3b5999127ecb96256c38d5dbf49ed2864c087ed2a80b783901d0aa3ba1", size = 195835, upload-time = "2026-08-04T14:43:09.19Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/9b/31f0b49a2542ffa2f9d6140267e2b568e722a1feeb05cfbffea97666c62b/caio-0.12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:40ebea9ebe3a3a66ae85fa00d4112d163654a33c82dcf9b26a99f7d30de13317", size = 84656, upload-time = "2026-08-04T14:43:10.513Z" },
+    { url = "https://files.pythonhosted.org/packages/99/bc/62568d688af9712a34fe3f958d7a98c53bb2017e263260cd5deae67a90e9/caio-0.12.2-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:6003ec389a68d5ec8f089df82b2dc8915293dd630a4d11322d7e3455045981fd", size = 198443, upload-time = "2026-08-04T14:43:11.767Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/e4/5ed627860285612e5307f06c109913c5918c947fbc223b55599e484c64b0/caio-0.12.2-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:eee9376d0e2af25b6defc5bce39f6efa90521c803aaf12eba931bd898a397cfc", size = 196356, upload-time = "2026-08-04T14:43:13.206Z" },
+    { url = "https://files.pythonhosted.org/packages/81/e2/2a8cfc6ba3ef3f19e7c778e9fb6f98600f0971cca78bbdfc23a413a66349/caio-0.12.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:78e3ccafc98e009fcb00a97ad441585551e52c0ae7ecc50427a3ccd9b11502fd", size = 195893, upload-time = "2026-08-04T14:43:14.649Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/87/77c40fb2301d0b5bb27c2e79ae42fce718ed75396d5fe3e1c09d8e1400b1/caio-0.12.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f2355db8917f5a0f3638bf332fe0d87549c80e978fca01db84a8a14b9df56a05", size = 195969, upload-time = "2026-08-04T14:43:15.946Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/b5/0ceca97eb546fe6bbace3399c8b11dfc503efcc7509d708a7a3f09ab50e9/caio-0.12.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8054cba5e7ee623bea34946e2b59eb7c7c2be8872d0a5d12215d6ff564938d5f", size = 78621, upload-time = "2026-08-04T14:43:17.316Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/43/54d01cf9b643ffd6678aedee5ad5d6e7a1063bd169a203bfb6fb471e6887/caio-0.12.2-cp314-cp314-macosx_26_0_arm64.whl", hash = "sha256:5d658212d585b8814b9caf766d8090acac05f01abfa2875d57fdc4a7e2af032e", size = 77834, upload-time = "2026-08-04T14:43:18.492Z" },
+    { url = "https://files.pythonhosted.org/packages/90/00/a0ca7394a0c3a234811b0c38b39aa0db9373663981c1cf446e26e7a7c198/caio-0.12.2-cp314-cp314-manylinux_2_34_aarch64.whl", hash = "sha256:391a7cc1dbfc5885d7d54406c9a7a4ec19d514d526e67d240d32734eebde378e", size = 198993, upload-time = "2026-08-04T14:43:19.992Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/b2/f8f1a5e57c16c86825f1f0648e76f7760f84452a41efee0d04fa53ef3e2d/caio-0.12.2-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:121f4de82e2a875aff468ef2af7491fbecfffe9e71b507f5073fe2a156bb78df", size = 196408, upload-time = "2026-08-04T14:43:21.3Z" },
+    { url = "https://files.pythonhosted.org/packages/01/db/5d94d1d58ef6f0acb39ab1a802793413a8b1e17108c05cf98cb4dc9e4b22/caio-0.12.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e0ba5f8c0dc7035c05817ca1399dd7d6121ea55c363a079c334a151a75094322", size = 196480, upload-time = "2026-08-04T14:43:22.812Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/2a/366adf468d7654b895e232eeaa80d147df2ba293f708bd9cef78b95f92d0/caio-0.12.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:0ad8d8f9f5ea47aee81aead563fe3aca5bb54c3fc21b62bd830eaf369eb04060", size = 196071, upload-time = "2026-08-04T14:43:24.187Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b1/4c0c989d2a24b8f3ba2e13b9115a107d9413b36aab8b299674b66da21c75/caio-0.12.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0b85f94819058a8f21c3dca26c5f006a0f003b8700483a326ec86d569d2bd1a3", size = 78627, upload-time = "2026-08-04T14:43:25.522Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/da/107cfe84199b9fb5a7317e1230d808944205fd91c7869641ac4e2ef5d603/caio-0.12.2-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:a60459e42c680068a2a5286f15f54ccd887af34ad9ed1be1f0a7747ad6bd8820", size = 220217, upload-time = "2026-08-04T14:43:26.823Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/1c/d6f03d3226519cd8f362081370326846348c442078e005753c57522a4190/caio-0.12.2-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:51bb86c0abce55d0b3467ba6671e95cd96356044e5abd58651ad0645cf37084b", size = 216293, upload-time = "2026-08-04T14:43:28.177Z" },
+    { url = "https://files.pythonhosted.org/packages/43/a4/d53ed7e639b778b6f41a5e7c664b37f75830e38afa62dad62ec913674548/caio-0.12.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e33295963f5a4787355b8bfd754b4f0e7ac5d535138860748c1eb833ca10d620", size = 218220, upload-time = "2026-08-04T14:43:29.656Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d6/c353fd1dda371262995bba1b2f9aa42cc6cf7fc82c0853238510aa655bb9/caio-0.12.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:15af6eb10d7705a92ee8143d8a4d89c2886ecb6b65ce1161d3dad1adb9b3cbec", size = 216106, upload-time = "2026-08-04T14:43:31.011Z" },
+    { url = "https://files.pythonhosted.org/packages/61/8a/71b0144f783468ba9f1bbf8a2f8e45c7d85ae31ec192f10650aa46f31702/caio-0.12.2-py3-none-any.whl", hash = "sha256:5233e797c9fe2b541914b1bc2e2df82677e2206b537e44e252188f3c2cbb0ea9", size = 62548, upload-time = "2026-08-04T14:43:32.394Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "colorlog"
+version = "6.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/55/ba79756cb90c8d69d599d57785398ac87bba7b19c80e87f4e8a562197c93/colorlog-6.12.0.tar.gz", hash = "sha256:2a7924c1dadf18b22a0eb8b06d1c7b01d5341707ec1641eb6fcc4fde0c3e8e5f", size = 18151, upload-time = "2026-07-23T13:40:40.71Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/19/0b6647bf5e331521e55d2b63bfbdc210bd9cd605189273f03614a05f702d/colorlog-6.12.0-py3-none-any.whl", hash = "sha256:30d392604e9110045a2c2aeefc27d7a017abbab63f3a8aee594eac0801df784e", size = 12239, upload-time = "2026-07-23T13:40:39.562Z" },
+]
+
+[[package]]
+name = "logging-journald"
+version = "0.6.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/df/c013c3d8f37a351ceb35f166bc9a0a69365655ab13eb4366032e96c6da33/logging_journald-0.6.12.tar.gz", hash = "sha256:d6bd338460b5ecd88f6b3e9a6499a6994c65d5d8296f3aa4830b25a7d7e815a9", size = 7747, upload-time = "2026-07-30T20:31:27.609Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/f3/2b2033e02f6a08eaefed14351056b797f780c7f5aaa6765e66d734fac91b/logging_journald-0.6.12-py3-none-any.whl", hash = "sha256:b94d1c7082d7a7ddc69f8fc1a6cf420da3d97a03363c12659859fec09f44f811", size = 7080, upload-time = "2026-07-30T20:31:26.517Z" },
+]


### PR DESCRIPTION
Addresses #88.

- stdlib, aiofile (every caio backend), aiofiles, aiomisc.io
- linear/random, read/write, buffered/O_DIRECT, sequential/concurrent
- fresh temp file per pass, offset-tagged content verification
- raw TSV to stdout, no aggregation; plot_results.py renders a report from it

Results from one Linux/ext4 run included under `benchmark/results/` (gzipped TSV/log + PNG report, via git-lfs).

## Test plan
- [x] `bench.py` run on Linux (ext4, all 4 caio backends) -- 0 content-verification failures
- [x] `plot_results.py` run against the resulting TSV -- report renders correctly